### PR TITLE
remove `typing` module dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     packages=find_packages(exclude=[u'contrib', u'docs', u'tests', u'tools']),
     install_requires=[
         u'six>=1.10.0',
-        u'typing>=3.5.2',
     ],
     extras_require={
         u'dev': [u'pylint>=1.5.6'],


### PR DESCRIPTION
This is related to https://github.com/python/typing/issues/573: `typing` is now part of the Python standard library.  Adding `typing` as dependency to modules will lead to the installation a second, incompatible versions of that module.